### PR TITLE
refactor: mandrill_api_key because all of the underscores

### DIFF
--- a/lib/mandrill.rb
+++ b/lib/mandrill.rb
@@ -17,15 +17,10 @@ module Mandrill
             @session = Excon.new @host
             @debug = debug
 
-            if not apikey
-                if ENV['MANDRILL_APIKEY']
-                    apikey = ENV['MANDRILL_APIKEY']
-                else
-                    apikey = read_configs
-                end
-            end
+            # Note: For transitional phase so as not to break <many> apps
+            apikey ||= ENV['MANDRILL_API_KEY'] || ENV['MANDRILL_APIKEY'] || read_configs
 
-            raise Error, 'You must provide a Mandrill API key' if not apikey
+            raise Error, 'You must provide a Mandrill API key' unless apikey
             @apikey = apikey
         end
 

--- a/mandrill-api.gemspec
+++ b/mandrill-api.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
     s.name = 'mandrill-api-neos'
-    s.version = '1.0.55'
+    s.version = '1.0.56'
     s.summary = 'A Ruby API library for the Mandrill email as a service platform.  Originally on https://bitbucket.org/mailchimp/mandrill-api-ruby/'
     s.description = s.summary
     s.authors = ['Mandrill Devs']


### PR DESCRIPTION
... because this is how we have decided to standardise names